### PR TITLE
feature: add MetaAggregationRouter

### DIFF
--- a/abis/AggregationRouterMeta.json
+++ b/abis/AggregationRouterMeta.json
@@ -1,0 +1,277 @@
+[
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_WETH", "type": "address" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "clientData",
+        "type": "bytes"
+      }
+    ],
+    "name": "ClientData",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "reason",
+        "type": "string"
+      }
+    ],
+    "name": "Error",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "pair",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amountOut",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "output",
+        "type": "address"
+      }
+    ],
+    "name": "Exchange",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "contract IERC20",
+        "name": "srcToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "contract IERC20",
+        "name": "dstToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "dstReceiver",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "spentAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "returnAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Swapped",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "WETH",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "token", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "rescueFunds",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IAggregationExecutor",
+        "name": "caller",
+        "type": "address"
+      },
+      {
+        "components": [
+          {
+            "internalType": "contract IERC20",
+            "name": "srcToken",
+            "type": "address"
+          },
+          {
+            "internalType": "contract IERC20",
+            "name": "dstToken",
+            "type": "address"
+          },
+          {
+            "internalType": "address[]",
+            "name": "srcReceivers",
+            "type": "address[]"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "srcAmounts",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "address",
+            "name": "dstReceiver",
+            "type": "address"
+          },
+          { "internalType": "uint256", "name": "amount", "type": "uint256" },
+          {
+            "internalType": "uint256",
+            "name": "minReturnAmount",
+            "type": "uint256"
+          },
+          { "internalType": "uint256", "name": "flags", "type": "uint256" },
+          { "internalType": "bytes", "name": "permit", "type": "bytes" }
+        ],
+        "internalType": "struct AggregationRouter.SwapDescription",
+        "name": "desc",
+        "type": "tuple"
+      },
+      { "internalType": "bytes", "name": "executorData", "type": "bytes" },
+      { "internalType": "bytes", "name": "clientData", "type": "bytes" }
+    ],
+    "name": "swap",
+    "outputs": [
+      { "internalType": "uint256", "name": "returnAmount", "type": "uint256" }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IAggregationExecutor",
+        "name": "caller",
+        "type": "address"
+      },
+      {
+        "components": [
+          {
+            "internalType": "contract IERC20",
+            "name": "srcToken",
+            "type": "address"
+          },
+          {
+            "internalType": "contract IERC20",
+            "name": "dstToken",
+            "type": "address"
+          },
+          {
+            "internalType": "address[]",
+            "name": "srcReceivers",
+            "type": "address[]"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "srcAmounts",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "address",
+            "name": "dstReceiver",
+            "type": "address"
+          },
+          { "internalType": "uint256", "name": "amount", "type": "uint256" },
+          {
+            "internalType": "uint256",
+            "name": "minReturnAmount",
+            "type": "uint256"
+          },
+          { "internalType": "uint256", "name": "flags", "type": "uint256" },
+          { "internalType": "bytes", "name": "permit", "type": "bytes" }
+        ],
+        "internalType": "struct AggregationRouter.SwapDescription",
+        "name": "desc",
+        "type": "tuple"
+      },
+      { "internalType": "bytes", "name": "executorData", "type": "bytes" },
+      { "internalType": "bytes", "name": "clientData", "type": "bytes" }
+    ],
+    "name": "swapSimpleMode",
+    "outputs": [
+      { "internalType": "uint256", "name": "returnAmount", "type": "uint256" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "newOwner", "type": "address" }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  { "stateMutability": "payable", "type": "receive" }
+]

--- a/config/arbitrum.json
+++ b/config/arbitrum.json
@@ -11,5 +11,9 @@
     "routerMeta": {
         "address": "0x617Dee16B86534a5d792A4d7A62FB491B544111E",
         "startBlock": "18689322"
+    },
+    "graft": {
+        "id": "QmS4yexH8aFMtzPbfZvXbVZN6auaF7CBLP1kQLifVDut2p",
+        "block": "18689321"
     }
 }

--- a/config/arbitrum.json
+++ b/config/arbitrum.json
@@ -7,5 +7,9 @@
     "routerV3": {
         "address": "0x00555513Acf282B42882420E5e5bA87b44D8fA6E",
         "startBlock": "9490342"
+    },
+    "routerMeta": {
+        "address": "0x617Dee16B86534a5d792A4d7A62FB491B544111E",
+        "startBlock": "15224303"
     }
 }

--- a/config/arbitrum.json
+++ b/config/arbitrum.json
@@ -10,6 +10,6 @@
     },
     "routerMeta": {
         "address": "0x617Dee16B86534a5d792A4d7A62FB491B544111E",
-        "startBlock": "15224303"
+        "startBlock": "18689322"
     }
 }

--- a/config/aurora.json
+++ b/config/aurora.json
@@ -11,5 +11,9 @@
     "routerV3": {
         "address": "0x00555513Acf282B42882420E5e5bA87b44D8fA6E",
         "startBlock": "62945165"
+    },
+    "graft": {
+        "id": "QmYxzyRWRopZjoYWM533v7BYVTYrwxwfFFiLXnVZEEtYA3",
+        "block": "70880540"
     }
 }

--- a/config/avalanche.json
+++ b/config/avalanche.json
@@ -14,6 +14,6 @@
   },
   "routerMeta": {
     "address": "0x617Dee16B86534a5d792A4d7A62FB491B544111E",
-    "startBlock": "15224303"
+    "startBlock": "17866165"
   }
 }

--- a/config/avalanche.json
+++ b/config/avalanche.json
@@ -15,5 +15,9 @@
   "routerMeta": {
     "address": "0x617Dee16B86534a5d792A4d7A62FB491B544111E",
     "startBlock": "17866165"
+  },
+  "graft": {
+    "id": "QmVUvygiJJBxccLfY94VWnZ8DHATGTFwrLiXHjfd29xJXe",
+    "block": "17866164"
   }
 }

--- a/config/avalanche.json
+++ b/config/avalanche.json
@@ -11,5 +11,9 @@
   "routerV3": {
     "address": "0x00555513Acf282B42882420E5e5bA87b44D8fA6E",
     "startBlock": "13142129"
+  },
+  "routerMeta": {
+    "address": "0x617Dee16B86534a5d792A4d7A62FB491B544111E",
+    "startBlock": "15224303"
   }
 }

--- a/config/bsc.json
+++ b/config/bsc.json
@@ -11,5 +11,9 @@
   "routerV3": {
     "address": "0x00555513Acf282B42882420E5e5bA87b44D8fA6E",
     "startBlock": "16704288"
+  },
+  "routerMeta": {
+    "address": "0x617Dee16B86534a5d792A4d7A62FB491B544111E",
+    "startBlock": "15224303"
   }
 }

--- a/config/bsc.json
+++ b/config/bsc.json
@@ -14,6 +14,6 @@
   },
   "routerMeta": {
     "address": "0x617Dee16B86534a5d792A4d7A62FB491B544111E",
-    "startBlock": "15224303"
+    "startBlock": "19915368"
   }
 }

--- a/config/bsc.json
+++ b/config/bsc.json
@@ -15,5 +15,9 @@
   "routerMeta": {
     "address": "0x617Dee16B86534a5d792A4d7A62FB491B544111E",
     "startBlock": "19915368"
+  },
+  "graft": {
+    "id": "QmQXUu2NTpd2kQkuhzXFj1Pdx6YYt3xQLc7HznpTewbpEE",
+    "block": "19915367"
   }
 }

--- a/config/bttc.json
+++ b/config/bttc.json
@@ -7,5 +7,9 @@
   "routerV3": {
     "address": "0x00555513Acf282B42882420E5e5bA87b44D8fA6E",
     "startBlock": "4901498"
+  },
+  "graft": {
+    "id": "QmYVpPwQ3ikhwuZzwrUJPh4tB1JAz18MNdmZDoQAH55Q7M",
+    "block": "9665599"
   }
 }

--- a/config/cronos.json
+++ b/config/cronos.json
@@ -11,5 +11,9 @@
   "routerV3": {
     "address": "0x00555513Acf282B42882420E5e5bA87b44D8fA6E",
     "startBlock": "2254419"
+  },
+  "graft": {
+    "id": "QmdhHAPREPKJtxDWHGd7vWcbfB5oq4njPPMqPAVj9n7fzm",
+    "block": "3911216"
   }
 }

--- a/config/ethereum.json
+++ b/config/ethereum.json
@@ -11,5 +11,9 @@
   "routerV3": {
     "address": "0x00555513Acf282B42882420E5e5bA87b44D8fA6E",
     "startBlock": "14570076"
+  },
+  "routerMeta": {
+    "address": "0x617Dee16B86534a5d792A4d7A62FB491B544111E",
+    "startBlock": "15224303"
   }
 }

--- a/config/ethereum.json
+++ b/config/ethereum.json
@@ -15,5 +15,9 @@
   "routerMeta": {
     "address": "0x617Dee16B86534a5d792A4d7A62FB491B544111E",
     "startBlock": "15224303"
+  },
+  "graft": {
+    "id": "QmNbae2oYpfaMYq6jjhEfmfgfBpdWGAFJpFkMLa7316WtV",
+    "block": "15224302"
   }
 }

--- a/config/fantom.json
+++ b/config/fantom.json
@@ -11,5 +11,9 @@
   "routerV3": {
     "address": "0x00555513Acf282B42882420E5e5bA87b44D8fA6E",
     "startBlock": "35526281"
+  },
+  "routerMeta": {
+    "address": "0x617Dee16B86534a5d792A4d7A62FB491B544111E",
+    "startBlock": "15224303"
   }
 }

--- a/config/fantom.json
+++ b/config/fantom.json
@@ -14,6 +14,6 @@
   },
   "routerMeta": {
     "address": "0x617Dee16B86534a5d792A4d7A62FB491B544111E",
-    "startBlock": "15224303"
+    "startBlock": "43654228"
   }
 }

--- a/config/fantom.json
+++ b/config/fantom.json
@@ -15,5 +15,9 @@
   "routerMeta": {
     "address": "0x617Dee16B86534a5d792A4d7A62FB491B544111E",
     "startBlock": "43654228"
+  },
+  "graft": {
+    "id": "QmV5MbGzfosivosXwKphtrkxEm3tsTaM1APCR5pGuBFNdH",
+    "block": "43654227"
   }
 }

--- a/config/oasis.json
+++ b/config/oasis.json
@@ -7,5 +7,9 @@
     "routerV3": {
         "address": "0x00555513Acf282B42882420E5e5bA87b44D8fA6E",
         "startBlock": "962276"
+    },
+    "graft": {
+        "id": "QmPcdh7VGxAZQgNCsiEeKJHxu1ZfFXmfMHAbmjFhz8JF7Z",
+        "block": "2239308"
     }
 }

--- a/config/optimism.json
+++ b/config/optimism.json
@@ -3,5 +3,9 @@
     "routerV3": {
         "address": "0x00555513Acf282B42882420E5e5bA87b44D8fA6E",
         "startBlock": "12133691"
+    },
+    "routerMeta": {
+        "address": "0x617Dee16B86534a5d792A4d7A62FB491B544111E",
+        "startBlock": "15224303"
     }
 }

--- a/config/optimism.json
+++ b/config/optimism.json
@@ -7,5 +7,9 @@
     "routerMeta": {
         "address": "0x617Dee16B86534a5d792A4d7A62FB491B544111E",
         "startBlock": "16012849"
+    },
+    "graft": {
+        "id": "QmVU15UWRtZyM9oTw9EHPqvdMmoRU33LRiMLUaoqEAwVNe",
+        "block": "16012848"
     }
 }

--- a/config/optimism.json
+++ b/config/optimism.json
@@ -6,6 +6,6 @@
     },
     "routerMeta": {
         "address": "0x617Dee16B86534a5d792A4d7A62FB491B544111E",
-        "startBlock": "15224303"
+        "startBlock": "16012849"
     }
 }

--- a/config/polygon.json
+++ b/config/polygon.json
@@ -14,6 +14,6 @@
   },
   "routerMeta": {
     "address": "0x617Dee16B86534a5d792A4d7A62FB491B544111E",
-    "startBlock": "15224303"
+    "startBlock": "31194679"
   }
 }

--- a/config/polygon.json
+++ b/config/polygon.json
@@ -15,5 +15,9 @@
   "routerMeta": {
     "address": "0x617Dee16B86534a5d792A4d7A62FB491B544111E",
     "startBlock": "31194679"
+  },
+  "graft": {
+    "id": "QmVRLWb1MssBndZfu1vuJurT9VDWDCbfNuk1okhtFr4Yoy",
+    "block": "31194678"
   }
 }

--- a/config/polygon.json
+++ b/config/polygon.json
@@ -11,5 +11,9 @@
   "routerV3": {
     "address": "0x00555513Acf282B42882420E5e5bA87b44D8fA6E",
     "startBlock": "26806784"
+  },
+  "routerMeta": {
+    "address": "0x617Dee16B86534a5d792A4d7A62FB491B544111E",
+    "startBlock": "15224303"
   }
 }

--- a/config/velas.json
+++ b/config/velas.json
@@ -7,5 +7,9 @@
     "routerV3": {
         "address": "0x00555513Acf282B42882420E5e5bA87b44D8fA6E",
         "startBlock": "29831930"
+    },
+    "graft": {
+        "id": "QmX3wVk9AHxutQWDzHFudJumUf6eddbu6u6aCHd94PXkmV",
+        "block": "46913558"
     }
 }

--- a/subgraphs/router.thegraph.yaml
+++ b/subgraphs/router.thegraph.yaml
@@ -75,6 +75,31 @@ dataSources:
           handler: handleSwapped
         - event: ClientData(bytes)
           handler: handleClientData
+  - kind: ethereum/contract
+    name: RouterMeta
+    network: bsc
+    source:
+      address: '0x617Dee16B86534a5d792A4d7A62FB491B544111E'
+      abi: RouterMeta
+      startBlock: 19915368
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.5
+      language: wasm/assemblyscript
+      file: ../src/router/router.ts
+      entities:
+        - RouterExchange
+        - RouterSwapped
+      abis:
+        - name: RouterMeta
+          file: ../abis/AggregationRouterMeta.json
+      eventHandlers:
+        - event: Exchange(address,uint256,address)
+          handler: handleExchange
+        - event: Swapped(address,address,address,address,uint256,uint256)
+          handler: handleSwapped
+        - event: ClientData(bytes)
+          handler: handleClientData
 templates:
   - kind: ethereum/contract
     name: Executor

--- a/subgraphs/router.thegraph.yaml
+++ b/subgraphs/router.thegraph.yaml
@@ -3,6 +3,9 @@ description: Router
 repository: https://github.com/kybernetwork/aggregator-subgraph
 schema:
   file: ./router.graphql
+graft:
+  base: QmQXUu2NTpd2kQkuhzXFj1Pdx6YYt3xQLc7HznpTewbpEE # Subgraph ID of base subgraph
+  block: 19915367 # Block number
 dataSources:
   - kind: ethereum/contract
     name: Router

--- a/templates/router.template.yaml
+++ b/templates/router.template.yaml
@@ -81,6 +81,33 @@ dataSources:
         - event: ClientData(bytes)
           handler: handleClientData
   {{/routerV3}}
+  {{#routerMeta}}
+  - kind: ethereum/contract
+    name: RouterMeta
+    network: {{network}}
+    source:
+      address: '{{routerMeta.address}}'
+      abi: RouterMeta
+      startBlock: {{routerMeta.startBlock}}
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.5
+      language: wasm/assemblyscript
+      file: ../src/router/router.ts
+      entities:
+        - RouterExchange
+        - RouterSwapped
+      abis:
+        - name: RouterMeta
+          file: ../abis/AggregationRouterMeta.json
+      eventHandlers:
+        - event: Exchange(address,uint256,address)
+          handler: handleExchange
+        - event: Swapped(address,address,address,address,uint256,uint256)
+          handler: handleSwapped
+        - event: ClientData(bytes)
+          handler: handleClientData
+  {{/routerMeta}}
 templates:
   - kind: ethereum/contract
     name: Executor

--- a/templates/router.template.yaml
+++ b/templates/router.template.yaml
@@ -3,6 +3,9 @@ description: Router
 repository: https://github.com/kybernetwork/aggregator-subgraph
 schema:
   file: ./router.graphql
+graft:
+  base: {{graft.id}} # Subgraph ID of base subgraph
+  block: {{graft.block}} # Block number
 dataSources:
   {{#router}}
   - kind: ethereum/contract


### PR DESCRIPTION
We released MetaAggregationRouter on 7 chains: Ethereum, BSC, Polygon, Avalanche, Fantom, Arbitrum & Optimism. This PR is for adding meta aggregator subgraph for these chains